### PR TITLE
Fix auto apply for edit changes

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1127,6 +1127,30 @@
         hide: function(e) {
             if (!this.isShowing) return;
 
+            if (this.autoApply) {
+                var dateString = [
+                    this.container.find('input[name=daterangepicker_start]').val(),
+                    this.container.find('input[name=daterangepicker_end]').val()
+                ];
+
+                if (dateString.length === 2) {
+                    start = moment(dateString[0], this.locale.format);
+                    end = moment(dateString[1], this.locale.format);
+                }
+
+                if (this.singleDatePicker || start === null || end === null) {
+                    start = moment(this.element.val(), this.locale.format);
+                    end = start;
+                }
+
+                if (start.isValid() || end.isValid()) {
+                    this.setStartDate(start);
+                    this.setEndDate(end);
+
+                    this.element.trigger('apply.daterangepicker', this);
+                }
+            }
+
             //incomplete date selection, revert to last values
             if (!this.endDate) {
                 this.startDate = this.oldStartDate.clone();


### PR DESCRIPTION
When autoApply is true, the hide method should update its startDate and endDate with the current values in the edits, so as to pass the right values to the callback or any events. This is necessary because outsideClick is bound way before any changes happen. And finally it should trigger apply.daterangepicker, as one would expect.