### PR TITLE
Add updateTextOnHover option

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -41,6 +41,7 @@
         this.autoApply = false;
         this.singleDatePicker = false;
         this.showDropdowns = false;
+        this.updateTextOnHover = true;
         this.showWeekNumbers = false;
         this.showISOWeekNumbers = false;
         this.showCustomRangeLabel = true;
@@ -233,6 +234,9 @@
 
         if (typeof options.showDropdowns === 'boolean')
             this.showDropdowns = options.showDropdowns;
+
+        if (typeof options.updateTextOnHover === 'boolean')
+            this.updateTextOnHover = options.updateTextOnHover;
 
         if (typeof options.showCustomRangeLabel === 'boolean')
             this.showCustomRangeLabel = options.showCustomRangeLabel;
@@ -1262,10 +1266,12 @@
             var cal = $(e.target).parents('.calendar');
             var date = cal.hasClass('left') ? this.leftCalendar.calendar[row][col] : this.rightCalendar.calendar[row][col];
 
-            if (this.endDate && !this.container.find('input[name=daterangepicker_start]').is(":focus")) {
-                this.container.find('input[name=daterangepicker_start]').val(date.format(this.locale.format));
-            } else if (!this.endDate && !this.container.find('input[name=daterangepicker_end]').is(":focus")) {
-                this.container.find('input[name=daterangepicker_end]').val(date.format(this.locale.format));
+            if (this.updateTextOnHover) {
+              if (this.endDate && !this.container.find('input[name=daterangepicker_start]').is(":focus")) {
+                  this.container.find('input[name=daterangepicker_start]').val(date.format(this.locale.format));
+              } else if (!this.endDate && !this.container.find('input[name=daterangepicker_end]').is(":focus")) {
+                  this.container.find('input[name=daterangepicker_end]').val(date.format(this.locale.format));
+              }
             }
 
             //highlight the dates between the start date and the date being hovered as a potential end date


### PR DESCRIPTION
The way the text box updates on hover can create a confusing user experience.  After selecting the end date, the start date text box changes to the end date because that is where the mouse is hovering.  This feels unexpected because an interaction with the end date seems to be changing the start date.