### PR TITLE
Introduce a new option alwaysToggle to fix #1490

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -51,6 +51,7 @@
         this.linkedCalendars = true;
         this.autoUpdateInput = true;
         this.alwaysShowCalendars = false;
+        this.alwaysToggle = false;
         this.ranges = {};
 
         this.opens = 'right';
@@ -258,6 +259,9 @@
         if (typeof options.autoApply === 'boolean')
             this.autoApply = options.autoApply;
 
+        if (typeof options.alwaysToggle === 'boolean')
+            this.alwaysToggle = options.alwaysToggle;
+
         if (typeof options.autoUpdateInput === 'boolean')
             this.autoUpdateInput = options.autoUpdateInput;
 
@@ -434,7 +438,7 @@
             .on('mouseenter.daterangepicker', 'li', $.proxy(this.hoverRange, this))
             .on('mouseleave.daterangepicker', 'li', $.proxy(this.updateFormInputs, this));
 
-        if (this.element.is('input') || this.element.is('button')) {
+        if (!this.alwaysToggle && (this.element.is('input') || this.element.is('button'))) {
             this.element.on({
                 'click.daterangepicker': $.proxy(this.show, this),
                 'focus.daterangepicker': $.proxy(this.show, this),

--- a/website/index.html
+++ b/website/index.html
@@ -634,6 +634,9 @@
                                 option to specify pre-defined date ranges, calendars for choosing a custom date range are not shown until the user clicks "Custom Range". When this option is set to true, the calendars for choosing a custom date range are always shown instead.
                             </li>
                             <li>
+                                <code>alwaysToggle</code>: (boolean) By default, <code>input</code> and <code>button</code> will show the picker, while all other elements will toggle it. If this option is set to true, any element will toggle the picker.
+                            </li>
+                            <li>
                                 <code>opens</code>: (string</code>: 'left'/'right'/'center') Whether the picker appears aligned to the left, to the right, or centered under the HTML element it's attached to
                             </li>
                             <li>


### PR DESCRIPTION
As describe in #1490, `input` and `button` trigger a show, while all other elements trigger a toggle. This behavior shouldn't change for backwards compatibility, so I've intruduced a new option `alwaysToggle`, which makes any element trigger toggle.



  