### PR TITLE
Fix when user typed date in any input and clicked anywhere outside da…

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1131,6 +1131,18 @@
         hide: function(e) {
             if (!this.isShowing) return;
 
+             // ***start*** validation when user click out datepicker without unfocus any date input
+            var inputStartDateVal = moment(this.container.find('input[name=daterangepicker_start]').val(), this.locale.format);
+            var inputEndDateVal = moment(this.container.find('input[name=daterangepicker_end]').val(), this.locale.format);
+           
+            //ensure the comparison is right, if user type 20012018 when he/she means 20/01/2018
+            if (inputStartDateVal.isValid() && inputStartDateVal.format(this.locale.format) != this.startDate.format(this.locale.format))
+                this.startDate = moment(inputStartDateVal.format(this.locale.format), this.locale.format);
+
+            if (inputEndDateVal.isValid() && inputEndDateVal.format(this.locale.format) != this.endDate.format(this.locale.format))
+                this.entDate = moment(inputEndDateVal.format(this.locale.format), this.locale.format);
+            // ***end*** validation when user click out datepicker without unfocus any date input
+            
             //incomplete date selection, revert to last values
             if (!this.endDate) {
                 this.startDate = this.oldStartDate.clone();


### PR DESCRIPTION
…teragenpicker without unfocus any date input

Validation and treatment when user typed date in any input and clicked anywhere outside dateragenpicker without unfocus any date input.
Ex.:
![image](https://user-images.githubusercontent.com/6000766/35335053-80102df2-00fb-11e8-9f23-e77223f87475.png)
