### PR TITLE
Add show-ranges class to datepicker

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -392,6 +392,10 @@
             this.container.addClass('show-calendar');
         }
 
+        if ((!this.autoApply || typeof options.ranges === 'object') && (!this.singleDatePicker || this.timePicker)) {
+          this.container.addClass('show-ranges');
+        }
+
         this.container.addClass('opens' + this.opens);
 
         //swap the position of the predefined ranges if opens right


### PR DESCRIPTION
Hi! In this PR I want to add a `show-ranges` class to the daterangepicker container when ranges tab is visible. The class will apply if ranges list or apply/cancel button is visible.
The general purpose of this class is a CSS customization of daterangepicker.