### PR TITLE
Rename the `calendar` CSS class to avoid conflicts

### DIFF
--- a/daterangepicker.css
+++ b/daterangepicker.css
@@ -88,7 +88,7 @@
   border-top: 6px solid #fff;
 }
 
-.daterangepicker.single .daterangepicker .ranges, .daterangepicker.single .calendar {
+.daterangepicker.single .daterangepicker .ranges, .daterangepicker.single .drp-calendar {
   float: none;
 }
 
@@ -96,7 +96,7 @@
   display: none;
 }
 
-.daterangepicker.show-calendar .calendar {
+.daterangepicker.show-calendar .drp-calendar {
   display: block;
 }
 
@@ -108,20 +108,20 @@
   display: none;
 }
 
-.daterangepicker .calendar {
+.daterangepicker .drp-calendar {
   display: none;
   max-width: 270px;
 }
 
-.daterangepicker .calendar.left {
+.daterangepicker .drp-calendar.left {
   padding: 8px 0 8px 8px;
 }
 
-.daterangepicker .calendar.right {
+.daterangepicker .drp-calendar.right {
   padding: 8px;
 }
 
-.daterangepicker .calendar.single .calendar-table {
+.daterangepicker .drp-calendar.single .calendar-table {
   border: none;
 }
 
@@ -286,7 +286,7 @@
   padding: 4px 8px;
 }
 
-.daterangepicker.show-ranges .calendar.left {
+.daterangepicker.show-ranges .drp-calendar.left {
   border-left: 1px solid #ddd;
 }
 
@@ -330,51 +330,51 @@
       width: 140px; }
     .daterangepicker.single .ranges ul {
       width: 100%; }
-    .daterangepicker.single .calendar.left {
+    .daterangepicker.single .drp-calendar.left {
       clear: none; }
-    .daterangepicker.single.ltr .ranges, .daterangepicker.single.ltr .calendar {
+    .daterangepicker.single.ltr .ranges, .daterangepicker.single.ltr .drp-calendar {
       float: left; }
-    .daterangepicker.single.rtl .ranges, .daterangepicker.single.rtl .calendar {
+    .daterangepicker.single.rtl .ranges, .daterangepicker.single.rtl .drp-calendar {
       float: right; }
     .daterangepicker.ltr {
       direction: ltr;
       text-align: left; }
-      .daterangepicker.ltr .calendar.left {
+      .daterangepicker.ltr .drp-calendar.left {
         clear: left;
         margin-right: 0; }
-        .daterangepicker.ltr .calendar.left .calendar-table {
+        .daterangepicker.ltr .drp-calendar.left .calendar-table {
           border-right: none;
           border-top-right-radius: 0;
           border-bottom-right-radius: 0; }
-      .daterangepicker.ltr .calendar.right {
+      .daterangepicker.ltr .drp-calendar.right {
         margin-left: 0; }
-        .daterangepicker.ltr .calendar.right .calendar-table {
+        .daterangepicker.ltr .drp-calendar.right .calendar-table {
           border-left: none;
           border-top-left-radius: 0;
           border-bottom-left-radius: 0; }
-      .daterangepicker.ltr .calendar.left .calendar-table {
+      .daterangepicker.ltr .drp-calendar.left .calendar-table {
         padding-right: 8px; }
-      .daterangepicker.ltr .ranges, .daterangepicker.ltr .calendar {
+      .daterangepicker.ltr .ranges, .daterangepicker.ltr .drp-calendar {
         float: left; }
     .daterangepicker.rtl {
       direction: rtl;
       text-align: right; }
-      .daterangepicker.rtl .calendar.left {
+      .daterangepicker.rtl .drp-calendar.left {
         clear: right;
         margin-left: 0; }
-        .daterangepicker.rtl .calendar.left .calendar-table {
+        .daterangepicker.rtl .drp-calendar.left .calendar-table {
           border-left: none;
           border-top-left-radius: 0;
           border-bottom-left-radius: 0; }
-      .daterangepicker.rtl .calendar.right {
+      .daterangepicker.rtl .drp-calendar.right {
         margin-right: 0; }
-        .daterangepicker.rtl .calendar.right .calendar-table {
+        .daterangepicker.rtl .drp-calendar.right .calendar-table {
           border-right: none;
           border-top-right-radius: 0;
           border-bottom-right-radius: 0; }
-      .daterangepicker.rtl .calendar.left .calendar-table {
+      .daterangepicker.rtl .drp-calendar.left .calendar-table {
         padding-left: 12px; }
-      .daterangepicker.rtl .ranges, .daterangepicker.rtl .calendar {
+      .daterangepicker.rtl .ranges, .daterangepicker.rtl .drp-calendar {
         text-align: right;
         float: right; } }
 @media (min-width: 730px) {
@@ -384,5 +384,5 @@
     float: left; }
   .daterangepicker.rtl .ranges {
     float: right; }
-  .daterangepicker .calendar.left {
+  .daterangepicker .drp-calendar.left {
     clear: none !important; } }

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -100,11 +100,11 @@
             options.template = 
             '<div class="daterangepicker">' +
                 '<div class="ranges"></div>' +
-                '<div class="calendar left">' +
+                '<div class="drp-calendar left">' +
                     '<div class="calendar-table"></div>' +
                     '<div class="calendar-time"></div>' +
                 '</div>' +
-                '<div class="calendar right">' +
+                '<div class="drp-calendar right">' +
                     '<div class="calendar-table"></div>' +
                     '<div class="calendar-time"></div>' +
                 '</div>' +
@@ -382,9 +382,9 @@
 
         if (this.singleDatePicker) {
             this.container.addClass('single');
-            this.container.find('.calendar.left').addClass('single');
-            this.container.find('.calendar.left').show();
-            this.container.find('.calendar.right').hide();
+            this.container.find('.drp-calendar.left').addClass('single');
+            this.container.find('.drp-calendar.left').show();
+            this.container.find('.drp-calendar.right').hide();
             if (!this.timePicker) {
                 this.container.addClass('auto-apply');
             }
@@ -409,7 +409,7 @@
         // event listeners
         //
 
-        this.container.find('.calendar')
+        this.container.find('.drp-calendar')
             .on('click.daterangepicker', '.prev', $.proxy(this.clickPrev, this))
             .on('click.daterangepicker', '.next', $.proxy(this.clickNext, this))
             .on('mousedown.daterangepicker', 'td.available', $.proxy(this.clickDate, this))
@@ -844,7 +844,7 @@
             html += '</tbody>';
             html += '</table>';
 
-            this.container.find('.calendar.' + side + ' .calendar-table').html(html);
+            this.container.find('.drp-calendar.' + side + ' .calendar-table').html(html);
 
         },
 
@@ -867,7 +867,7 @@
                 minDate = this.startDate;
 
                 //Preserve the time already selected
-                var timeSelector = this.container.find('.calendar.right .calendar-time');
+                var timeSelector = this.container.find('.drp-calendar.right .calendar-time');
                 if (timeSelector.html() != '') {
 
                     selected.hour(selected.hour() || timeSelector.find('.hourselect option:selected').val());
@@ -1005,7 +1005,7 @@
                 html += '</select>';
             }
 
-            this.container.find('.calendar.' + side + ' .calendar-time').html(html);
+            this.container.find('.drp-calendar.' + side + ' .calendar-time').html(html);
 
         },
 
@@ -1186,7 +1186,7 @@
         },
 
         clickPrev: function(e) {
-            var cal = $(e.target).parents('.calendar');
+            var cal = $(e.target).parents('.drp-calendar');
             if (cal.hasClass('left')) {
                 this.leftCalendar.month.subtract(1, 'month');
                 if (this.linkedCalendars)
@@ -1198,7 +1198,7 @@
         },
 
         clickNext: function(e) {
-            var cal = $(e.target).parents('.calendar');
+            var cal = $(e.target).parents('.drp-calendar');
             if (cal.hasClass('left')) {
                 this.leftCalendar.month.add(1, 'month');
             } else {
@@ -1222,7 +1222,7 @@
             var title = $(e.target).attr('data-title');
             var row = title.substr(1, 1);
             var col = title.substr(3, 1);
-            var cal = $(e.target).parents('.calendar');
+            var cal = $(e.target).parents('.drp-calendar');
             var date = cal.hasClass('left') ? this.leftCalendar.calendar[row][col] : this.rightCalendar.calendar[row][col];
 
             //highlight the dates between the start date and the date being hovered as a potential end date
@@ -1230,7 +1230,7 @@
             var rightCalendar = this.rightCalendar;
             var startDate = this.startDate;
             if (!this.endDate) {
-                this.container.find('.calendar tbody td').each(function(index, el) {
+                this.container.find('.drp-calendar tbody td').each(function(index, el) {
 
                     //skip week numbers, only look at dates
                     if ($(el).hasClass('week')) return;
@@ -1238,7 +1238,7 @@
                     var title = $(el).attr('data-title');
                     var row = title.substr(1, 1);
                     var col = title.substr(3, 1);
-                    var cal = $(el).parents('.calendar');
+                    var cal = $(el).parents('.drp-calendar');
                     var dt = cal.hasClass('left') ? leftCalendar.calendar[row][col] : rightCalendar.calendar[row][col];
 
                     if ((dt.isAfter(startDate) && dt.isBefore(date)) || dt.isSame(date, 'day')) {
@@ -1259,7 +1259,7 @@
             var title = $(e.target).attr('data-title');
             var row = title.substr(1, 1);
             var col = title.substr(3, 1);
-            var cal = $(e.target).parents('.calendar');
+            var cal = $(e.target).parents('.drp-calendar');
             var date = cal.hasClass('left') ? this.leftCalendar.calendar[row][col] : this.rightCalendar.calendar[row][col];
 
             //
@@ -1370,9 +1370,9 @@
         },
 
         monthOrYearChanged: function(e) {
-            var isLeft = $(e.target).closest('.calendar').hasClass('left'),
+            var isLeft = $(e.target).closest('.drp-calendar').hasClass('left'),
                 leftOrRight = isLeft ? 'left' : 'right',
-                cal = this.container.find('.calendar.'+leftOrRight);
+                cal = this.container.find('.drp-calendar.'+leftOrRight);
 
             // Month must be Number for new moment versions
             var month = parseInt(cal.find('.monthselect').val(), 10);
@@ -1413,7 +1413,7 @@
 
         timeChanged: function(e) {
 
-            var cal = $(e.target).closest('.calendar'),
+            var cal = $(e.target).closest('.drp-calendar'),
                 isLeft = cal.hasClass('left');
 
             var hour = parseInt(cal.find('.hourselect').val(), 10);


### PR DESCRIPTION
`calendar` is such a generic class name that it conflicts with other components.