### PR TITLE
make custom label selected after click

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1163,6 +1163,8 @@
             var label = e.target.getAttribute('data-range-key');
             this.chosenLabel = label;
             if (label == this.locale.customRangeLabel) {
+                this.container.find('.ranges li').removeClass('active');
+                this.container.find('.ranges li:last').addClass('active');
                 this.showCalendars();
             } else {
                 var dates = this.ranges[label];


### PR DESCRIPTION
make custom label selected after click.
related issue: 
 [Custom Range should be selected in expanded panel after click "Custom Range" ](https://github.com/dangrossman/daterangepicker/issues/1756)