### PR TITLE
Fix TypeError: moment is not a function(…)

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -11,7 +11,7 @@
         // AMD. Make globaly available as well
         define(['moment', 'jquery'], function (moment, jquery) {
             if (!jquery.fn) jquery.fn = {}; // webpack server rendering
-            if (typoeof moment === 'object' && moment.default) moment = moment.default
+            if (typeof moment !== 'function' && moment.default) moment = moment.default
             return factory(moment, jquery);
         });
     } else if (typeof module === 'object' && module.exports) {

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -11,6 +11,7 @@
         // AMD. Make globaly available as well
         define(['moment', 'jquery'], function (moment, jquery) {
             if (!jquery.fn) jquery.fn = {}; // webpack server rendering
+            if (typoeof moment === 'object' && moment.default) moment = moment.default
             return factory(moment, jquery);
         });
     } else if (typeof module === 'object' && module.exports) {


### PR DESCRIPTION
Hey, I have been using https://github.com/skratchdot/react-bootstrap-daterangepicker which wraps daterangepicker, we've migrated our site to React 16.4 from React 15 and encountered an error with the base library.

"TypeError: moment is not a function"

It appears when inserted into the webpack build, the library tries to use 'moment' however it receives an object instead of moment, the object contains a 'default' property that is the actual moment method.

I've added a check when the package is built via webpack to check if moment is not a function and whether it has a default property, and if so, override moment with moment.default and continue as usual.

This change fixed the error on our project and we're using a forked version for the meantime.

Thanks in advance for this awesome library.