### PR TITLE
added class control calendar-zone

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1140,6 +1140,7 @@
             if (
                 // ie modal dialog fix
                 e.type == "focusin" ||
+                target.hasClass('calendar-zone') ||
                 target.closest(this.element).length ||
                 target.closest(this.container).length ||
                 target.closest('.calendar-table').length

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1140,7 +1140,7 @@
             if (
                 // ie modal dialog fix
                 e.type == "focusin" ||
-                target.hasClass('calendar-zone') ||
+                target.hasClass('.calendar-zone') ||
                 target.closest(this.element).length ||
                 target.closest(this.container).length ||
                 target.closest('.calendar-table').length


### PR DESCRIPTION
Class used to avoid hide behaviour when a user clicks on elements with class "calendar-zone".

The idea is to have something that allow us to prevent the calendar to hide on clicking outside. In my use case i have two calendars opened at the same time (one for actual date and another to choose comparable dates) and i want the user to navigate freely between the two of them by clicking the start date input