### PR TITLE
Automatically disabling autocomplete for input elements to prevent browser overlapping.

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -55,6 +55,8 @@
         this.alwaysShowCalendars = false;
         this.ranges = {};
 
+        this.element.attr('autocomplete', 'off');
+
         this.opens = 'right';
         if (this.element.hasClass('pull-right'))
             this.opens = 'left';


### PR DESCRIPTION
This update automatically disabled autocomplete on the input field making it unnecessary to add in autocomplete="off" into your HTML.

You will never want autocomplete enabled as any suggestions overlap the display of the actual calendar.