### PR TITLE
setMaxDate functionality

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -449,6 +449,22 @@
 
         constructor: DateRangePicker,
 
+        setMaxDate: function (maxDate) {
+            if (typeof maxDate === 'string')
+                this.maxDate = moment(maxDate, this.locale.format);
+
+            if (typeof maxDate === 'object')
+                this.maxDate = moment(maxDate);
+
+            if (!this.timePicker)
+                this.maxDate = this.maxDate.startOf('day');
+
+            if (!this.isShowing)
+                this.updateElement();
+
+            this.updateMonthsInView();
+        },
+
         setStartDate: function(startDate) {
             if (typeof startDate === 'string')
                 this.startDate = moment(startDate, this.locale.format);


### PR DESCRIPTION
Created setMaxDate method in the daterangepicker's constructor so that if someone uses live dates for the datepickers he/she can still update selected date values without having problem with the upper limit of the maxDate. This way you can ensure (if needed) that the user can choose moment() as upper limit even if time is not static.