### PR TITLE
Correctly calculate chosen label hour

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1320,7 +1320,7 @@
             var i = 0;
             for (var range in this.ranges) {
               if (this.timePicker) {
-                    var format = this.timePickerSeconds ? "YYYY-MM-DD hh:mm:ss" : "YYYY-MM-DD hh:mm";
+                    var format = this.timePickerSeconds ? "YYYY-MM-DD HH:mm:ss" : "YYYY-MM-DD HH:mm";
                     //ignore times when comparing dates if time picker seconds is not enabled
                     if (this.startDate.format(format) == this.ranges[range][0].format(format) && this.endDate.format(format) == this.ranges[range][1].format(format)) {
                         customRange = false;


### PR DESCRIPTION
With the timePicker option enabled, if you have two labels (for example "last 12 hours" and "last 24 hours") and their start times happen to differ by 12 hours but are in the same day (yesterday at 10 AM and yesterday at 10 PM), the current master will always show "last 12 hours" as selected, even if the range is 24 hours.

This patch changes the format for comparing the currently selected range with labels in the picker so that 24-hour times are used, ensuring this doesn't happen.