### PR TITLE
Feature to dynamically limit the max days of range

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -163,6 +163,11 @@
               </div>
 
               <div class="form-group">
+                <label for="rangeDaysLimit">rangeDaysLimit</label>
+                <input type="text" class="form-control" id="rangeDaysLimit" value="0">
+              </div>
+
+              <div class="form-group">
                 <label for="opens">opens</label>
                 <select id="opens" class="form-control">
                   <option value="right" selected>right</option>
@@ -327,6 +332,9 @@
 
           if (!$('#showCustomRangeLabel').is(':checked'))
             options.showCustomRangeLabel = false;
+
+          if ($('#rangeDaysLimit').val() > 0)
+            options.rangeDaysLimit = parseInt($('#rangeDaysLimit').val());
 
           if ($('#alwaysShowCalendars').is(':checked'))
             options.alwaysShowCalendars = true;


### PR DESCRIPTION
Using this configuration, the user only can select a limited range of days after the selected start date.

When using this configuration, the cancel button is replaced with a reset button. It makes the exact same thing, except for closing the
calendar.