### PR TITLE
Revert "Fix for issue #1587"

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -489,7 +489,7 @@
                 this.endDate = moment(endDate);
 
             if (!this.timePicker)
-                this.endDate = this.endDate.add(1,'d').startOf('day').subtract(1,'second');
+                this.endDate = this.endDate.endOf('day');
 
             if (this.timePicker && this.timePickerIncrement)
                 this.endDate.minute(Math.round(this.endDate.minute() / this.timePickerIncrement) * this.timePickerIncrement);


### PR DESCRIPTION
Reverts dangrossman/daterangepicker#1588

This fixes one day but breaks the day before, on top of breaking time consistency with all the other dates all as detailed out here:
https://github.com/dangrossman/daterangepicker/issues/1890#issuecomment-450014401

<img width="721" alt="screen shot 2018-12-26 at 11 18 51 am" src="https://user-images.githubusercontent.com/431395/50455114-d635a280-0900-11e9-876e-cb53186d02d9.png">