### PR TITLE
Add identifying class to dates from prev/next month on calendar

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -787,7 +787,7 @@
 
                     //grey out the dates in other months displayed at beginning and end of this calendar
                     if (calendar[row][col].month() != calendar[1][1].month())
-                        classes.push('off');
+                        classes.push('off', 'ends');
 
                     //don't allow selection of dates before the minimum date
                     if (this.minDate && calendar[row][col].isBefore(this.minDate, 'day'))


### PR DESCRIPTION
Currently there's no way to distinguish a disabled date from one that's disabled and just from the prev/next month via css.

You can determine not disabled ends with `td.available.off`.   Items that are disabled and not current month end up with the class "off off disabled" which can't be selected for specifically.   The isCustom is unable to be used to distinguish this either since it's not passed if it's the left or right calendar.