### PR TITLE
Allow for singleDatePicker to disable autoApply

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -386,7 +386,7 @@
             this.container.find('.drp-calendar.left').addClass('single');
             this.container.find('.drp-calendar.left').show();
             this.container.find('.drp-calendar.right').hide();
-            if (!this.timePicker) {
+            if (!this.timePicker && this.autoApply) {
                 this.container.addClass('auto-apply');
             }
         }
@@ -1305,7 +1305,7 @@
 
             if (this.singleDatePicker) {
                 this.setEndDate(this.startDate);
-                if (!this.timePicker)
+                if (!this.timePicker && this.autoApply)
                     this.clickApply();
             }
 


### PR DESCRIPTION
As found in #1872, the auto apply option is ignored when using a single date picker, meaning that autoApply is by default set. This change allows for the autoApply config option to be used even in a singleDatePicker.