### PR TITLE
Add `locale.headerDateFormat` option

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# 4 space indentation
+# Indentation override for all
+[*]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ npm-debug.log
 *.sublime-workspace
 *.sublime-project
 *.sw[onp]
+
+## MacOS
+.DS_Store
+
+## JetBrain
+.idea

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -70,6 +70,11 @@
 
         this.locale = {
             direction: 'ltr',
+            headerDateFormat: 'MMM YYYY',
+            dateFormat: moment.localeData().longDateFormat('L'),
+            /** @deprecated
+             * `format` is Deprecated, Use `dateFormat`
+             * */
             format: moment.localeData().longDateFormat('L'),
             separator: ' - ',
             applyLabel: 'Apply',
@@ -128,8 +133,20 @@
             if (typeof options.locale.direction === 'string')
                 this.locale.direction = options.locale.direction;
 
-            if (typeof options.locale.format === 'string')
+            /** @deprecated */
+            if (typeof options.locale.format === 'string'){
                 this.locale.format = options.locale.format;
+                // Compatible with legacy variables.
+                this.locale.dateFormat = options.locale.format;
+                if ('warn' in console)
+                  console.warn('Use the `format` option instead of `dateFormat`.')
+            }
+
+            if (typeof options.locale.dateFormat === 'string')
+                this.locale.dateFormat = options.locale.dateFormat;
+
+            if (typeof options.locale.headerDateFormat === 'string')
+                this.locale.headerDateFormat = options.locale.headerDateFormat;
 
             if (typeof options.locale.separator === 'string')
                 this.locale.separator = options.locale.separator;
@@ -163,16 +180,16 @@
         this.container.addClass(this.locale.direction);
 
         if (typeof options.startDate === 'string')
-            this.startDate = moment(options.startDate, this.locale.format);
+            this.startDate = moment(options.startDate, this.locale.dateFormat);
 
         if (typeof options.endDate === 'string')
-            this.endDate = moment(options.endDate, this.locale.format);
+            this.endDate = moment(options.endDate, this.locale.dateFormat);
 
         if (typeof options.minDate === 'string')
-            this.minDate = moment(options.minDate, this.locale.format);
+            this.minDate = moment(options.minDate, this.locale.dateFormat);
 
         if (typeof options.maxDate === 'string')
-            this.maxDate = moment(options.maxDate, this.locale.format);
+            this.maxDate = moment(options.maxDate, this.locale.dateFormat);
 
         if (typeof options.startDate === 'object')
             this.startDate = moment(options.startDate);
@@ -298,11 +315,11 @@
                 start = end = null;
 
                 if (split.length == 2) {
-                    start = moment(split[0], this.locale.format);
-                    end = moment(split[1], this.locale.format);
+                    start = moment(split[0], this.locale.dateFormat);
+                    end = moment(split[1], this.locale.dateFormat);
                 } else if (this.singleDatePicker && val !== "") {
-                    start = moment(val, this.locale.format);
-                    end = moment(val, this.locale.format);
+                    start = moment(val, this.locale.dateFormat);
+                    end = moment(val, this.locale.dateFormat);
                 }
                 if (start !== null && end !== null) {
                     this.setStartDate(start);
@@ -315,12 +332,12 @@
             for (range in options.ranges) {
 
                 if (typeof options.ranges[range][0] === 'string')
-                    start = moment(options.ranges[range][0], this.locale.format);
+                    start = moment(options.ranges[range][0], this.locale.dateFormat);
                 else
                     start = moment(options.ranges[range][0]);
 
                 if (typeof options.ranges[range][1] === 'string')
-                    end = moment(options.ranges[range][1], this.locale.format);
+                    end = moment(options.ranges[range][1], this.locale.dateFormat);
                 else
                     end = moment(options.ranges[range][1]);
 
@@ -452,7 +469,7 @@
 
         setStartDate: function(startDate) {
             if (typeof startDate === 'string')
-                this.startDate = moment(startDate, this.locale.format);
+                this.startDate = moment(startDate, this.locale.dateFormat);
 
             if (typeof startDate === 'object')
                 this.startDate = moment(startDate);
@@ -483,7 +500,7 @@
 
         setEndDate: function(endDate) {
             if (typeof endDate === 'string')
-                this.endDate = moment(endDate, this.locale.format);
+                this.endDate = moment(endDate, this.locale.dateFormat);
 
             if (typeof endDate === 'object')
                 this.endDate = moment(endDate);
@@ -505,7 +522,7 @@
 
             this.previousRightTime = this.endDate.clone();
 
-            this.container.find('.drp-selected').html(this.startDate.format(this.locale.format) + this.locale.separator + this.endDate.format(this.locale.format));
+            this.container.find('.drp-selected').html(this.startDate.format(this.locale.dateFormat) + this.locale.separator + this.endDate.format(this.locale.dateFormat));
 
             if (!this.isShowing)
                 this.updateElement();
@@ -532,7 +549,7 @@
                 }
             }
             if (this.endDate)
-                this.container.find('.drp-selected').html(this.startDate.format(this.locale.format) + this.locale.separator + this.endDate.format(this.locale.format));
+                this.container.find('.drp-selected').html(this.startDate.format(this.locale.dateFormat) + this.locale.separator + this.endDate.format(this.locale.dateFormat));
             this.updateMonthsInView();
             this.updateCalendars();
             this.updateFormInputs();
@@ -704,7 +721,7 @@
                 html += '<th></th>';
             }
 
-            var dateHtml = this.locale.monthNames[calendar[1][1].month()] + calendar[1][1].format(" YYYY");
+            var dateHtml = calendar[1][1].format(this.locale.headerDateFormat);
 
             if (this.showDropdowns) {
                 var currentMonth = calendar[1][1].month();
@@ -915,7 +932,7 @@
                 if (maxDate && time.minute(0).isAfter(maxDate))
                     disabled = true;
 
-                if (i_in_24 == selected.hour() && !disabled) {
+              if (i_in_24 == selected.hour() && !disabled) {
                     html += '<option value="' + i + '" selected="selected">' + i + '</option>';
                 } else if (disabled) {
                     html += '<option value="' + i + '" disabled="disabled" class="disabled">' + i + '</option>';
@@ -1498,12 +1515,12 @@
                 end = null;
 
             if (dateString.length === 2) {
-                start = moment(dateString[0], this.locale.format);
-                end = moment(dateString[1], this.locale.format);
+                start = moment(dateString[0], this.locale.dateFormat);
+                end = moment(dateString[1], this.locale.dateFormat);
             }
 
             if (this.singleDatePicker || start === null || end === null) {
-                start = moment(this.element.val(), this.locale.format);
+                start = moment(this.element.val(), this.locale.dateFormat);
                 end = start;
             }
 
@@ -1531,9 +1548,9 @@
 
         updateElement: function() {
             if (this.element.is('input') && this.autoUpdateInput) {
-                var newValue = this.startDate.format(this.locale.format);
+                var newValue = this.startDate.format(this.locale.dateFormat);
                 if (!this.singleDatePicker) {
-                    newValue += this.locale.separator + this.endDate.format(this.locale.format);
+                    newValue += this.locale.separator + this.endDate.format(this.locale.dateFormat);
                 }
                 if (newValue !== this.element.val()) {
                     this.element.val(newValue).trigger('change');

--- a/demo.html
+++ b/demo.html
@@ -27,7 +27,7 @@
         <h1 style="margin: 0 0 20px 0">Configuration Builder</h1>
 
         <div class="well configurator">
-           
+
           <form>
           <div class="row">
 
@@ -36,6 +36,11 @@
               <div class="form-group">
                 <label for="parentEl">parentEl</label>
                 <input type="text" class="form-control" id="parentEl" value="" placeholder="body">
+              </div>
+
+              <div class="form-group">
+                <label for="headerDateFormat">headerDateFormat</label>
+                <input type="text" class="form-control" id="headerDateFormat" value="MMM YYYY" placeholder="MMM YYYY">
               </div>
 
               <div class="form-group">
@@ -235,7 +240,7 @@
         $('#config-text').keyup(function() {
           eval($(this).val());
         });
-        
+
         $('.configurator input, .configurator select').change(function() {
           updateConfig();
         });
@@ -261,7 +266,7 @@
 
           if ($('#singleDatePicker').is(':checked'))
             options.singleDatePicker = true;
-          
+
           if ($('#showDropdowns').is(':checked'))
             options.showDropdowns = true;
 
@@ -273,7 +278,7 @@
 
           if ($('#timePicker').is(':checked'))
             options.timePicker = true;
-          
+
           if ($('#timePicker24Hour').is(':checked'))
             options.timePicker24Hour = true;
 
@@ -282,7 +287,7 @@
 
           if ($('#timePickerSeconds').is(':checked'))
             options.timePickerSeconds = true;
-          
+
           if ($('#autoApply').is(':checked'))
             options.autoApply = true;
 
@@ -319,6 +324,9 @@
             $('#rtl-wrap').hide();
           }
 
+          if (!options.locale)
+            options.locale = {};
+
           if (!$('#linkedCalendars').is(':checked'))
             options.linkedCalendars = false;
 
@@ -334,12 +342,16 @@
           if ($('#parentEl').val().length)
             options.parentEl = $('#parentEl').val();
 
-          if ($('#startDate').val().length) 
+          if ($('#headerDateFormat').val().length) {
+            options.locale.headerDateFormat = $('#headerDateFormat').val();
+          }
+
+          if ($('#startDate').val().length)
             options.startDate = $('#startDate').val();
 
           if ($('#endDate').val().length)
             options.endDate = $('#endDate').val();
-          
+
           if ($('#minDate').val().length)
             options.minDate = $('#minDate').val();
 
@@ -364,7 +376,7 @@
           $('#config-text').val("$('#demo').daterangepicker(" + JSON.stringify(options, null, '    ') + ", function(start, end, label) {\n  console.log(\"New date range selected: ' + start.format('YYYY-MM-DD') + ' to ' + end.format('YYYY-MM-DD') + ' (predefined range: ' + label + ')\");\n});");
 
           $('#config-demo').daterangepicker(options, function(start, end, label) { console.log('New date range selected: ' + start.format('YYYY-MM-DD') + ' to ' + end.format('YYYY-MM-DD') + ' (predefined range: ' + label + ')'); }).click();;
-          
+
         }
 
       });


### PR DESCRIPTION
## Add `locale.headerDateFormat` option
> It can customize format the top of the calendar.

The `headerDateFormat` option has been added. Use this option to specify the date format at the top of calendar. Also, changed the name of the existing `format` option to` dateFormat`. This explains the function of more specific options. The existing `format` option is still compatible but is not recommended.

relates: #1501 #1785