### PR TITLE
fix rangeselection: autoApply not honoured

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1207,7 +1207,12 @@
 
                 if (!this.alwaysShowCalendars)
                     this.hideCalendars();
-                this.clickApply();
+                if (this.autoApply){
+                    this.clickApply(); // close picker 
+                }
+                else {
+                    this.updateCalendars(); // update displayed dateranges in calendar for further selection (e.g. time)
+                }
             }
         },
 


### PR DESCRIPTION
when clicking on one of the predefined ranges, clickApply was called causing the dialog to be closed; This is not beneficial e.g. when wanting to select a precise time after the daterange.

The dialog should therefore be only closed when the user has set the `autoApply` flag to true.