### PR TITLE
Calendar with position fixed issue solution

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1033,11 +1033,15 @@
                 parentRightEdge = this.parentEl[0].clientWidth + this.parentEl.offset().left;
             }
 
-            if (this.drops == 'up')
+            if (this.drops == 'up') {
                 containerTop = this.element.offset().top - this.container.outerHeight() - parentOffset.top;
-            else
-                containerTop = this.element.offset().top + this.element.outerHeight() - parentOffset.top;
-
+            } else {
+                if(this.element.css('position') == 'fixed') {
+                     containerTop = this.element.position().top + this.element.outerHeight(true)
+                } else {
+                    containerTop = this.element.offset().top + this.element.outerHeight() - parentOffset.top;
+                }
+            }
             // Force the container to it's actual width
             this.container.css({
               top: 0,


### PR DESCRIPTION
When daterangepicker is attached on element with position fixed on document scroll, the containerTop is calculating wrong, so in the particualr scenario we need the element.position