### PR TITLE
Usage of JS reserved word default breaks YUICompressor

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -11,7 +11,7 @@
         // AMD. Make globaly available as well
         define(['moment', 'jquery'], function (moment, jquery) {
             if (!jquery.fn) jquery.fn = {}; // webpack server rendering
-            if (typeof moment !== 'function' && moment.default) moment = moment.default
+            if (typeof moment !== 'function' && moment.hasOwnProperty('default')) moment = moment['default']
             return factory(moment, jquery);
         });
     } else if (typeof module === 'object' && module.exports) {


### PR DESCRIPTION
When compressing `daterangepicker.js` as part of an asset build pipeline using YUICompressor, this file breaks JS compilation due to invalid usage of the reserved keyword `default`