### PR TITLE
module.export is a function instead of calling it #1294

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -15,15 +15,16 @@
             return factory(moment, jquery);
         });
     } else if (typeof module === 'object' && module.exports) {
-        // Node / Browserify
-        //isomorphic issue
-        var jQuery = (typeof window != 'undefined') ? window.jQuery : undefined;
-        if (!jQuery) {
-            jQuery = require('jquery');
-            if (!jQuery.fn) jQuery.fn = {};
+        module.exports = function(moment, jQuery) {
+            if (!moment) {
+                moment = (typeof window != 'undefined' && typeof window.moment != 'undefined') ? window.moment : require('moment');
+            }
+            if ( !jQuery ) {
+                jQuery = (typeof window != 'undefined' && typeof window.jQuery != 'undefined') ? window.jQuery : require('jquery')
+            }
+
+            return factory( moment, jQuery);
         }
-        var moment = (typeof window != 'undefined' && typeof window.moment != 'undefined') ? window.moment : require('moment');
-        module.exports = factory(moment, jQuery);
     } else {
         // Browser globals
         root.daterangepicker = factory(root.moment, root.jQuery);


### PR DESCRIPTION
When we want to import module in our project we need to provide with a jQuery, so that is why I changed `module.exports` to be a function with a moment and jQuery as parametars.

Here is example how I include in my project
```
  let moment = require('moment')
  let $ = require('jquery')
  require('daterangepicker')(moment, $)
  require('daterangepicker/daterangepicker.css')

```
